### PR TITLE
Add a next step in an annotation

### DIFF
--- a/.buildkite/annotation.md
+++ b/.buildkite/annotation.md
@@ -1,0 +1,3 @@
+✨ **You've run a build!** ✨
+
+Ready for the next adventure? Create a pipeline for your own code. See [the docs](https://buildkite.com/docs/pipelines/create-your-own) to learn more.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ steps:
     depends_on: build
 
   - label: ":rocket: Deploy"
-    command: echo "Launch the rocket"
+    command: |
+      echo "Launch the rocket"
+      cat .buildkite/annotation.md | buildkite-agent annotate --style "success"
     key: deploy
     depends_on: test


### PR DESCRIPTION
This change:

- Adds an annotation to the deploy command step.
- Adds a new file with the text of the annotation.

The goal is to suggest a next step using the new docs page, while keeping the configuration file clear and minimal.